### PR TITLE
style: improve colors and links structure

### DIFF
--- a/frontend/src/components/ElectionCardComponent.vue
+++ b/frontend/src/components/ElectionCardComponent.vue
@@ -10,19 +10,11 @@
         <li>
           <strong>End:</strong> {{ ("0" + election.end.getUTCDate()).slice(-2) }} {{ election.end.toLocaleString('default', { month: 'short' }) }} {{election.end.getFullYear() }} {{ election.end.getHours() }}:{{ ("0" + election.end.getMinutes()).slice(-2) }}
         </li>
-        <li>
-          <div class="card links mx-auto">
-            <ul>
-              <li>
-                <a :href="`/elections/${election.id}`">See details</a>
-              </li>
-              <li v-if="isOpen(election)">
-                <a :href="`/vote/${election.id}`">Cast a vote</a>
-              </li>
-            </ul>
-          </div>
-        </li>
       </ul>
+      <div class="d-flex flex-column links">
+        <a :href="`/elections/${election.id}`">See details</a>
+        <a :href="`/vote/${election.id}`">Cast a vote</a>
+      </div>
     </div>
   </div>
 </template>
@@ -55,14 +47,16 @@ function isOpen(election: VotingWithStatus): boolean {
     text-decoration: none;
   }
 
-  div.links {
-    display: inline-block;
-    padding: 4%;
+  div.links a {
+    padding: 6px 0;
+    margin: 4px 0;
+    border-radius: 15px;
+    background-color: #edede9;
   }
 
-  .links ul {
-    margin-left: 0;
-    padding-left: 0;
+  div.links a:hover {
+    font-weight: bold;
+    box-shadow: 1px 2px 5px rgba(200, 200, 200, 0.82);
   }
 
   .card {

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -2,7 +2,7 @@
   <Breadcrumb :paths="[{name: 'Dashboard', link: '/dashboard'}]" />
   <PageTitle title="Dashboard" />
   <div v-for="qualifier in qualifiers" :class="`elections col-10 center mx-auto election election-${qualifier} bg-light`" :key="`div-${qualifier}`">
-    <a :href="`/elections?qualifier=${qualifier}`" class="election-link">{{ capitalizeFirstLetter(qualifier) }} Elections</a>
+    <h2><a :href="`/elections?qualifier=${qualifier}`" class="election-link">{{ capitalizeFirstLetter(qualifier) }} Elections</a></h2>
     <hr v-if="getData(qualifier).length > 0"/>
     <Carousel :elections="sortElectionsByDate(getData(qualifier))"/>
   </div>
@@ -104,9 +104,16 @@ function getData(qualifier: string) {
 </script>
 
 <style>
+  .elections {
+    margin: 4% 0;
+  }
+
+  .elections h2 {
+    font-size: 1.6em;
+  }
+
   .election-link {
     color: black;
-    font-weight: bold;
     text-decoration: none;
   }
 
@@ -119,14 +126,10 @@ function getData(qualifier: string) {
     border-color: inherit;
   }
 
-  .elections {
-    margin: 4% 0;
-  }
-
   .election {
     margin: 2% 0;
     border-radius: 15px;
-    box-shadow: 1px 3px 10px rgba(200, 200, 200, 0.82);
+    box-shadow: 3px 3px 10px rgba(200, 200, 200, 0.82);
     padding: 2%;
     button {
       color: black;
@@ -135,7 +138,7 @@ function getData(qualifier: string) {
 </style>
 
 <style lang="scss">
-  $color-open: #66FF99;
+  $color-open: #009f00;
   .election-open {
     border: $color-open 2px solid;
     a:hover {
@@ -145,7 +148,7 @@ function getData(qualifier: string) {
       color: $color-open;
     }
   }
-  $color-closed: red;
+  $color-closed: #c70224;
   .election-closed {
     border: $color-closed 2px solid;
     a:hover {


### PR DESCRIPTION
This PR includes the following style adjustment proposals:
- less bright colors
- improved styling for buttons
- add titles for "[open | closed | soon] elections"

**Before**:
<img width="1318" alt="before" src="https://github.com/tassiLuca/ChainVote/assets/39587905/11c1c0c9-2c83-4f85-b2c0-6c041c6eb992">

**After**:
<img width="1339" alt="after" src="https://github.com/tassiLuca/ChainVote/assets/39587905/79dad8a1-ddb6-4432-83cd-4478f11158d2">
